### PR TITLE
Add time functions

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,5 +12,6 @@ t/03-stdout.t
 t/04-stderr.t
 t/05-object.t
 t/06-signal.t
+t/07-time.t
 t/pod-coverage.t
 t/pod.t

--- a/t/05-object.t
+++ b/t/05-object.t
@@ -1,6 +1,6 @@
 #!perl
 
-use Test::More tests => 38;
+use Test::More tests => 41;
 
 use Test::Command;
 
@@ -58,6 +58,12 @@ $test_perl->stderr_like(qr/BAR\nFOO/i);
 $test_perl->stderr_unlike(qr/BAR\nFOO/);
 $test_perl->stderr_cmp_ok('ne', "foo\nbar\n");
 $test_perl->stderr_is_file("$FindBin::Bin/stderr.txt");
+
+my $time = $test_perl->time_value;
+ok( $time > 0.0001 && $time < 0.1, 'command ran between 0.0001 and 0.1 seconds' );
+
+$test_perl->time_gt(0.0001);
+$test_perl->time_lt(0.1);
 
 ## test object with ARRAY ref command
 

--- a/t/07-time.t
+++ b/t/07-time.t
@@ -1,0 +1,31 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::Command tests => 3;
+
+use Test::More;
+
+## determine whether we can run perl or not
+
+system qq($^X -e 1) and BAIL_OUT('error calling perl via system');
+
+my $time = time_value(_sleep_secs(0.01));
+ok( $time > 0.001 && $time < 0.1,
+    'command sleeps between 0.001 and 0.1 seconds' );
+
+time_lt(_sleep_secs(0.01), 0.1);
+
+time_gt(_sleep_secs(0.01), 0.005);
+
+## sleep given seconds using system calling perl
+sub _sleep_secs
+   {
+   my ($seconds) = @_;
+
+   my $MICROSECONDS_IN_ONE_SECOND = 1_000_000;
+   $seconds *= $MICROSECONDS_IN_ONE_SECOND;
+
+   return qq($^X -MTime::HiRes=usleep -e "usleep $seconds");
+   }


### PR DESCRIPTION
Add functions to test run time of the command. The functions
are:
- time_lt($cmd, $seconds, $name)
- time_gt($cmd, $seconds, $name)
- time_value($cmd)
